### PR TITLE
Add Agentlane snippet to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=Lato:wght@400;700&display=swap" rel="stylesheet">
+  <script src="https://api.agentlane.com/v1/snippet.js" data-domain="dom-rd8kro9g0i9q"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Adds the Agentlane analytics snippet to the `<head>` of `index.html`.

```html
<script src="https://api.agentlane.com/v1/snippet.js" data-domain="dom-rd8kro9g0i9q"></script>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)